### PR TITLE
修复mapper-locations配置为根路径时，文件修改后热加载失败的问题

### DIFF
--- a/src/main/java/io/github/wayn111/mybatis/xmlreload/MybatisXmlReload.java
+++ b/src/main/java/io/github/wayn111/mybatis/xmlreload/MybatisXmlReload.java
@@ -68,7 +68,9 @@ public class MybatisXmlReload {
                 if (tmpFile.exists()) {
                     locationPatternSet.add(Paths.get(tmpFile.getParent()));
                     FileSystemResource fileSystemResource = new FileSystemResource(tmpFile);
-                    mapperLocations.add(fileSystemResource);
+                    if (!mapperLocations.contains(fileSystemResource)) {
+                        mapperLocations.add(fileSystemResource);
+                    }
                 } else {
                     locationPatternSet.add(Paths.get(mapperLocation.getFile().getParent()));
                 }


### PR DESCRIPTION
修复mapper-locations配置为项目根路径时，同时扫描到target和/src/main/resources下的同一个Mapper，导致mapperLocations中存在两个相同的Mapper路径，继而文件修改后热加载失败的问题