### PR TITLE
fix:优先从MybatisConfiguration读取配置，若找不到则在父类Configuration中获取

### DIFF
--- a/src/main/java/io/github/wayn111/mybatis/xmlreload/MybatisXmlReload.java
+++ b/src/main/java/io/github/wayn111/mybatis/xmlreload/MybatisXmlReload.java
@@ -99,9 +99,30 @@ public class MybatisXmlReload {
                                     Set<String> loadedResources = (Set<String>) getFieldValue(targetConfiguration, aClass, "loadedResources");
                                     loadedResources.clear();
 
-                                    Map<String, ResultMap> resultMaps = (Map<String, ResultMap>) getFieldValue(targetConfiguration, tClass, "resultMaps");
-                                    Map<String, XNode> sqlFragmentsMaps = (Map<String, XNode>) getFieldValue(targetConfiguration, tClass, "sqlFragments");
-                                    Map<String, MappedStatement> mappedStatementMaps = (Map<String, MappedStatement>) getFieldValue(targetConfiguration, tClass, "mappedStatements");
+                                    //mybatis3.5.6中下面的属性在Configuration类中，直接从Configuration中无法获取
+                                    // 优先从MybatisConfiguration读取配置，若找不到则在父类Configuration中获取
+                                    Map<String, ResultMap> resultMaps = null;
+                                    try{
+                                        resultMaps = (Map<String, ResultMap>) getFieldValue(targetConfiguration, tClass, "resultMaps");
+                                    }catch (NoSuchFieldException ex){
+                                        resultMaps = (Map<String, ResultMap>) getFieldValue(targetConfiguration, aClass, "resultMaps");
+                                    }
+
+                                    Map<String, XNode> sqlFragmentsMaps = null;
+                                    try{
+                                        sqlFragmentsMaps = (Map<String, XNode>)  getFieldValue(targetConfiguration, tClass, "sqlFragments");
+                                    }catch (NoSuchFieldException ex){
+                                        sqlFragmentsMaps = (Map<String, XNode>)  getFieldValue(targetConfiguration, aClass, "sqlFragments");
+                                    }
+
+                                    Map<String, MappedStatement> mappedStatementMaps = null;
+                                    try{
+                                        mappedStatementMaps = (Map<String, MappedStatement>) getFieldValue(targetConfiguration, tClass, "mappedStatements");
+                                    }catch (NoSuchFieldException ex){
+                                        mappedStatementMaps = (Map<String, MappedStatement>) getFieldValue(targetConfiguration, aClass, "mappedStatements");
+                                    }
+
+
 
                                     for (Resource mapperLocation : mapperLocations) {
                                         if (!mapperLocation.isFile()) {


### PR DESCRIPTION
![image](https://github.com/wayn111/mybatis-xmlreload-spring-boot-starter/assets/18401515/9d0bbf98-5825-4105-89e3-20537f788a58)
mybatis3.5.6中下面的属性在Configuration类中，直接从Configuration中无法获取